### PR TITLE
made roomid consistent throughout services

### DIFF
--- a/server/src/services/roomService.ts
+++ b/server/src/services/roomService.ts
@@ -3,7 +3,7 @@ import Room from '../models/rooms';
 import { RoomCreationAttributes } from 'room-types';
 
 class RoomService {
-  public async getRoomById(roomID: number): Promise<Room | null> {
+  public async getRoomById(roomID: string): Promise<Room | null> {
     const room = await Room.findOne({ where: { roomID: roomID } });
     return room;
   }

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -90,7 +90,7 @@ class UserService {
     return rooms;
   }
 
-  public async getRoomUser(roomID: number, username: string): Promise<RoomUser | null> {
+  public async getRoomUser(roomID: string, username: string): Promise<RoomUser | null> {
     if (await Room.findOne({ where: { roomID: roomID } }) == null) {
       throw new Error('getRoomUser: Room not found');
     }
@@ -100,7 +100,7 @@ class UserService {
     return roomUser;
   }
 
-  public async createRoomUser(roomID: number, roomUser: RoomUserAttributes): Promise<RoomUser> {
+  public async createRoomUser(roomID: string, roomUser: RoomUserAttributes): Promise<RoomUser> {
     if (await this.getRoomUser(roomID, roomUser.username) != null) {
       throw new Error('createRoomUser: User already in room');
     }

--- a/server/tests/services/roomService.test.ts
+++ b/server/tests/services/roomService.test.ts
@@ -1,3 +1,4 @@
+import { mock } from 'node:test';
 import Room from '../../src/models/rooms';
 import RoomService from '../../src/services/roomService';
 
@@ -8,7 +9,7 @@ describe('RoomService', () => {
   let mockRoom: Room;
   beforeEach(() => {
     mockRoom = {
-      roomID: 1,
+      roomID: 'mockID',
       roomName: 'Test Room',
       roomOwner: 'Test Owner',
     } as Room;
@@ -19,17 +20,17 @@ describe('RoomService', () => {
   it('getRoomById should return room when found', async () => {
     (Room.findOne as jest.Mock).mockResolvedValue(mockRoom);
 
-    const room = await RoomService.getRoomById(1);
+    const room = await RoomService.getRoomById(mockRoom.roomID);
     expect(room).toEqual(mockRoom);
-    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: 1 } });
+    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: mockRoom.roomID } });
   });
 
   it('getRoomById should return null when room not found', async () => {
     (Room.findOne as jest.Mock).mockResolvedValue(null);
 
-    const room = await RoomService.getRoomById(999);
+    const room = await RoomService.getRoomById(mockRoom.roomID);
     expect(room).toBeNull();
-    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: 999 } });
+    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: mockRoom.roomID } });
   });
 
   /* Tests for createRoom */

--- a/server/tests/services/userService.test.ts
+++ b/server/tests/services/userService.test.ts
@@ -21,16 +21,16 @@ describe('UserService', () => {
   });
 
   const mockRooms = [
-    { roomID: 1 }, 
-    { roomID: 2 }
+    { roomID: 'mockID-1' }, 
+    { roomID: 'mockID-2' }
   ] as Room[];
   const mockRoomUsers = [
-    { roomID: 3, username: 'testuser1' }, 
-    { roomID: 4, username: 'testuser2' }
+    { roomID: 'mockID-3', username: 'testuser1' }, 
+    { roomID: 'mockID-4', username: 'testuser2' }
   ] as RoomUser[];
   const mockRoomsJoined = [
-    { roomID: 4 }, 
-    { roomID: 4 }
+    { roomID: 'mockID-3' }, 
+    { roomID: 'mockID-4' }
   ] as Room[];
 
   /* Tests for getUserByUsername */
@@ -229,9 +229,9 @@ describe('UserService', () => {
     jest.spyOn(Room, 'findOne').mockResolvedValue(true as unknown as Room);
     jest.spyOn(RoomUser, 'findOne').mockResolvedValue(mockRoomUsers[0] as unknown as RoomUser);
 
-    const result = await UserService.getRoomUser(1, mockUser.username);
+    const result = await UserService.getRoomUser(mockRooms[0].roomID, mockUser.username);
 
-    expect(RoomUser.findOne).toHaveBeenCalledWith({ where: { roomID: 1, username: mockUser.username } });
+    expect(RoomUser.findOne).toHaveBeenCalledWith({ where: { roomID: mockRooms[0].roomID, username: mockUser.username } });
     expect(result).toBe(mockRoomUsers[0]);
   });
 
@@ -239,19 +239,19 @@ describe('UserService', () => {
     jest.spyOn(Room, 'findOne').mockResolvedValue(true as unknown as Room);
     jest.spyOn(RoomUser, 'findOne').mockResolvedValue(null);
 
-    const result = await UserService.getRoomUser(1, mockUser.username);
+    const result = await UserService.getRoomUser(mockRooms[0].roomID, mockUser.username);
 
-    expect(RoomUser.findOne).toHaveBeenCalledWith({ where: { roomID: 1, username: mockUser.username } });
+    expect(RoomUser.findOne).toHaveBeenCalledWith({ where: { roomID: mockRooms[0].roomID, username: mockUser.username } });
     expect(result).toBe(null);
   });
 
   it('getRoomUser - should throw an error if room not found', async () => {
     jest.spyOn(Room, 'findOne').mockResolvedValue(null);
 
-    const result = UserService.getRoomUser(1, mockUser.username);
+    const result = UserService.getRoomUser(mockRooms[0].roomID, mockUser.username);
 
     await expect(result).rejects.toThrow('Room not found');
-    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: 1 } });
+    expect(Room.findOne).toHaveBeenCalledWith({ where: { roomID: mockRooms[0].roomID } });
   });
 
   /* Tests for createRoomUser */
@@ -259,9 +259,9 @@ describe('UserService', () => {
     jest.spyOn(UserService, 'getRoomUser').mockResolvedValue(null);
     jest.spyOn(RoomUser, 'create').mockResolvedValue(mockRoomUsers[0] as unknown as RoomUser);
 
-    const result = await UserService.createRoomUser(1, mockRoomUsers[0] as unknown as RoomUser);
+    const result = await UserService.createRoomUser(mockRooms[0].roomID, mockRoomUsers[0] as unknown as RoomUser);
 
-    expect(UserService.getRoomUser).toHaveBeenCalledWith(1, mockRoomUsers[0].username);
+    expect(UserService.getRoomUser).toHaveBeenCalledWith(mockRooms[0].roomID, mockRoomUsers[0].username);
     expect(RoomUser.create).toHaveBeenCalledWith(mockRoomUsers[0]);
     expect(result).toBe(mockRoomUsers[0]);
   });
@@ -269,10 +269,10 @@ describe('UserService', () => {
   it('createRoomUser - should throw an error if room user already exists', async () => {
     jest.spyOn(UserService, 'getRoomUser').mockResolvedValue(mockRoomUsers[0] as unknown as RoomUser);
 
-    const result = UserService.createRoomUser(1, mockRoomUsers[0] as unknown as RoomUser);
+    const result = UserService.createRoomUser(mockRooms[0].roomID, mockRoomUsers[0] as unknown as RoomUser);
 
     await expect(result).rejects.toThrow('User already in room');
-    expect(UserService.getRoomUser).toHaveBeenCalledWith(1, mockRoomUsers[0].username);
+    expect(UserService.getRoomUser).toHaveBeenCalledWith(mockRooms[0].roomID, mockRoomUsers[0].username);
   });
 
   /* Tests for removeRoomUser */


### PR DESCRIPTION
## Type of Change
- [ x ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
Changes to the roomID type were not reflected in the service classes. This PR fixes that.

## Description
Type compatibilty errors broke the service classes.

## Changelog
userService.ts and roomService.ts (and tests for both)

## Footer
Reference number: #54 
Closes: #54 
