### PR TITLE
update body on dark mode toggle

### DIFF
--- a/client/src/utilities/page-wrapper.tsx
+++ b/client/src/utilities/page-wrapper.tsx
@@ -50,6 +50,12 @@ export const asPage = (Component: any) => {
 
         const session = SessionState.getInstance();
         session.updateDarkMode(!session.getDarkMode());
+
+        if (!this.state.darkMode) {
+          document.body.setAttribute('data-theme', 'dark');
+        } else {
+          document.body.removeAttribute('data-theme');
+        }
       };
     }
 
@@ -62,6 +68,10 @@ export const asPage = (Component: any) => {
             isLoadingCache: false,
             darkMode: SessionState.getInstance().getDarkMode(),
           });
+
+          if (SessionState.getInstance().getDarkMode()) {
+            document.body.setAttribute('data-theme', 'dark');
+          }
         });
 
       window.addEventListener('beforeunload', this.handleUnload);


### PR DESCRIPTION
## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
Certain shadcn components render in portals. Because of this, the dark mode tag must be applied to the body tag.

## Description
Added a check for dark mode on mount and toggle in the page wrapper. Added/removed body tag accordingly to toggle dark mode.

## Changelog
client/src/utilities/page-wrapper.tsx

## Footer
Reference number: #85 
Closes: #85
