### PR TITLE
passed param to file router, made available to middleware

### DIFF
--- a/server/src/controllers/rooms/files.controller.ts
+++ b/server/src/controllers/rooms/files.controller.ts
@@ -22,12 +22,13 @@ export const getAllRoomFiles = async (req: Request, res: Response) => {
 
 export const createFile = async (req: Request, res: Response) => {
     const { roomID } = req.params;
+
     const fileBody: Types.FileData = req.body;
     if (!Validation.isFileDataCreation(fileBody)) {
         res.status(400).json({ error: "Bad Request: invalid format" });
         return;
     }
-    
+
     const roomFile: RoomFile = await filesService.createRoomFile({ roomID, ...fileBody });
     const roomFileResponse: Types.FileData = {
         fileId: roomFile.fileID,

--- a/server/src/middleware/setup.ts
+++ b/server/src/middleware/setup.ts
@@ -31,11 +31,20 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
 
 export const confirmUserInRoom = async (req: Request, res: Response, next: NextFunction) => {
   const user: User = (req as any).user;
+  
   const { roomID } = req.params;
+  if (!roomID) {
+    res.status(400).json({ error: "Bad Request: roomID is required" });
+    return;
+  }
 
   const room = await roomService.getRoomById(roomID);
   if (!room) {
     res.status(400).json({ error: "Bad Request: room does not exist" });
+    return;
+  }
+  if (room.roomOwner === user.username) {
+    next();
     return;
   }
   

--- a/server/src/routes/rooms.routes.ts
+++ b/server/src/routes/rooms.routes.ts
@@ -17,7 +17,7 @@ router.delete("/:roomID/users/:username", controller.removeUser)
 router.put("/:roomID/users/:username", controller.updateUser)
 
 // imported routers, users required to be part of the room to access
-router.use(confirmUserInRoom);
+router.use("/:roomID", confirmUserInRoom);
 router.use("/:roomID/markdown", filesRouter);
 
 export default router;

--- a/server/src/routes/rooms/files.routes.ts
+++ b/server/src/routes/rooms/files.routes.ts
@@ -1,11 +1,11 @@
 import { Router } from "express";
 import * as controller from "../../controllers/rooms/files.controller";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
 // TODO: any future permissions decisions to be implemented in middleware
 
-router.put("/", controller.getAllRoomFiles);
+router.get("/", controller.getAllRoomFiles);
 router.put("/", controller.createFile);
 
 router.get("/:fileName", controller.getRoomFile);


### PR DESCRIPTION
## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
Added param merging with file router and room router, allowing file router to inherit roomID param. Updated route for room middleware, also to capture roomID param.

## Description
The roomID param was not being passed to either the middleware or the file router, causing the server to crash.

## Changelog
modified server/src/routes/rooms.routes.ts and server/src/routes/rooms/files.routes.ts

## Footer
Reference number: #92 
Closes: #92 
