### PR TITLE
Client api wrapper for markdown endpoints

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -2,4 +2,5 @@ export * as Admin from './routes/admin';
 export * from './routes/misc';
 export * as Rooms from './routes/rooms';
 export * as User from './routes/user';
+export * as Files from './routes/files';
 export * from './types';

--- a/client/src/api/routes/files.ts
+++ b/client/src/api/routes/files.ts
@@ -1,0 +1,229 @@
+import { Types, Validation } from 'syncstream-sharedlib';
+import {
+  generateDefaultHeaders,
+  generateRoute,
+  printUnexpectedError,
+} from '../utilities';
+import { SuccessState } from '../types';
+
+export function getAllRoomFiles(roomID: string): Promise<{
+  success: SuccessState;
+  data?: Types.FileData[];
+}> {
+  const headers: Headers = generateDefaultHeaders();
+
+  // eslint-disable-next-line no-undef
+  const request: RequestInfo = new Request(
+    generateRoute(`rooms/${roomID}/files`),
+    {
+      method: 'GET',
+      headers,
+    },
+  );
+
+  return fetch(request)
+    .then(async (res) => {
+      if (res.status === 200) {
+        const body = await res.json();
+
+        for (let i = 0; i < body.length; i += 1) {
+          if (!Validation.isFileData(body[i])) {
+            return { success: SuccessState.ERROR };
+          }
+        }
+
+        return {
+          success: SuccessState.SUCCESS,
+          data: body as Types.FileData[],
+        };
+      }
+
+      if (res.status === 204) {
+        return {
+          success: SuccessState.SUCCESS,
+          data: [],
+        };
+      }
+
+      printUnexpectedError('rooms/{roomID}/markdown failed', res);
+      return { success: SuccessState.ERROR };
+    })
+    .catch((error) => {
+      console.error(`Fetch Encountered an Error:\n${error}`);
+      return { success: SuccessState.ERROR };
+    });
+}
+
+export function createFile(
+  roomID: string,
+  fileData: Types.FileData,
+): Promise<{
+  success: SuccessState;
+  data?: Types.FileData;
+}> {
+  const headers: Headers = generateDefaultHeaders();
+  headers.append('Content-Type', 'application/json');
+
+  // eslint-disable-next-line no-undef
+  const request: RequestInfo = new Request(
+    generateRoute(`rooms/${roomID}/files`),
+    {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(fileData),
+    },
+  );
+
+  return fetch(request)
+    .then(async (res) => {
+      if (res.status === 200) {
+        const body = await res.json();
+
+        if (!Validation.isFileData(body)) {
+          return { success: SuccessState.ERROR };
+        }
+
+        return {
+          success: SuccessState.SUCCESS,
+          data: body as Types.FileData,
+        };
+      }
+
+      if (res.status === 400) {
+        console.error('Create file failed: Bad Request.');
+        return { success: SuccessState.FAIL };
+      }
+
+      printUnexpectedError('rooms/{roomID}/files failed', res);
+      return { success: SuccessState.ERROR };
+    })
+    .catch((error) => {
+      console.error(`Fetch Encountered an Error:\n${error}`);
+      return { success: SuccessState.ERROR };
+    });
+}
+
+export function getRoomFile(
+  roomID: string,
+  fileName: string,
+): Promise<{
+  success: SuccessState;
+  data?: Types.FileData;
+}> {
+  const headers: Headers = generateDefaultHeaders();
+
+  // eslint-disable-next-line no-undef
+  const request: RequestInfo = new Request(
+    generateRoute(`rooms/${roomID}/files/${fileName}`),
+    {
+      method: 'GET',
+      headers,
+    },
+  );
+
+  return fetch(request)
+    .then(async (res) => {
+      if (res.status === 200) {
+        const body = await res.json();
+
+        if (!Validation.isFileData(body)) {
+          return { success: SuccessState.ERROR };
+        }
+
+        return {
+          success: SuccessState.SUCCESS,
+          data: body as Types.FileData,
+        };
+      }
+
+      if (res.status === 400) {
+        console.error('Get file failed: Bad Request.');
+        return { success: SuccessState.FAIL };
+      }
+
+      if (res.status === 404) {
+        console.error('Get file failed: Not Found.');
+        return { success: SuccessState.FAIL };
+      }
+
+      printUnexpectedError('rooms/{roomID}/files/{fileName} failed', res);
+      return { success: SuccessState.ERROR };
+    })
+    .catch((error) => {
+      console.error(`Fetch Encountered an Error:\n${error}`);
+      return { success: SuccessState.ERROR };
+    });
+}
+
+export function updateRoomFile(
+  roomID: string,
+  fileName: string,
+  fileData: Types.FileDataUpdate,
+): Promise<SuccessState> {
+  const headers: Headers = generateDefaultHeaders();
+
+  // eslint-disable-next-line no-undef
+  const request: RequestInfo = new Request(
+    generateRoute(`rooms/${roomID}/files/${fileName}`),
+    {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(fileData),
+    },
+  );
+
+  return fetch(request)
+    .then(async (res) => {
+      if (res.status === 204) return SuccessState.SUCCESS;
+
+      if (res.status === 400) {
+        console.error('Update file failed: Bad Request.');
+        return SuccessState.FAIL;
+      }
+
+      if (res.status === 404) {
+        console.error('Update file failed: Not Found.');
+        return SuccessState.FAIL;
+      }
+
+      printUnexpectedError('rooms/{roomID}/files/{fileName} failed', res);
+      return SuccessState.ERROR;
+    })
+    .catch((error) => {
+      console.error(`Fetch Encountered an Error:\n${error}`);
+      return SuccessState.ERROR;
+    });
+}
+
+export function deleteRoomFile(
+  roomID: string,
+  fileName: string,
+): Promise<SuccessState> {
+  const headers: Headers = generateDefaultHeaders();
+
+  // eslint-disable-next-line no-undef
+  const request: RequestInfo = new Request(
+    generateRoute(`rooms/${roomID}/files/${fileName}`),
+    {
+      method: 'DELETE',
+      headers,
+    },
+  );
+
+  return fetch(request)
+    .then(async (res) => {
+      if (res.status === 204) return SuccessState.SUCCESS;
+
+      if (res.status === 404) {
+        console.error('Delete file failed: Not Found.');
+        return SuccessState.FAIL;
+      }
+
+      printUnexpectedError('rooms/{roomID}/files/{fileName} failed', res);
+      return SuccessState.ERROR;
+    })
+    .catch((error) => {
+      console.error(`Fetch Encountered an Error:\n${error}`);
+      return SuccessState.ERROR;
+    });
+}

--- a/client/src/api/routes/files.ts
+++ b/client/src/api/routes/files.ts
@@ -62,7 +62,6 @@ export function createFile(
   data?: Types.FileData;
 }> {
   const headers: Headers = generateDefaultHeaders();
-  headers.append('Content-Type', 'application/json');
 
   // eslint-disable-next-line no-undef
   const request: RequestInfo = new Request(

--- a/client/src/pages/room/room.tsx
+++ b/client/src/pages/room/room.tsx
@@ -3,6 +3,7 @@ import { useParams, NavigateFunction } from 'react-router-dom';
 import SessionState from '../../utilities/session-state';
 import DocEditor from './editor/editor';
 import { asPage } from '../../utilities/page-wrapper';
+import * as api from '../../api';
 
 interface Props {
   // eslint-disable-next-line react/no-unused-prop-types

--- a/client/src/pages/room/room.tsx
+++ b/client/src/pages/room/room.tsx
@@ -3,7 +3,6 @@ import { useParams, NavigateFunction } from 'react-router-dom';
 import SessionState from '../../utilities/session-state';
 import DocEditor from './editor/editor';
 import { asPage } from '../../utilities/page-wrapper';
-import * as api from '../../api';
 
 interface Props {
   // eslint-disable-next-line react/no-unused-prop-types

--- a/server/src/controllers/rooms/files.controller.ts
+++ b/server/src/controllers/rooms/files.controller.ts
@@ -11,6 +11,11 @@ export const getAllRoomFiles = async (req: Request, res: Response) => {
 
     const roomFiles: RoomFile[] = await filesService.listAllFilesForRoom(roomID);
     
+    if (!roomFiles.length) {
+        res.sendStatus(204);
+        return;
+    }
+    
     const roomFilesResponse: Types.FileData[] = roomFiles.map((file) => ({
         fileID: file.fileID,
         fileName: file.fileName,

--- a/server/src/routes/rooms.routes.ts
+++ b/server/src/routes/rooms.routes.ts
@@ -18,6 +18,6 @@ router.put("/:roomID/users/:username", controller.updateUser)
 
 // imported routers, users required to be part of the room to access
 router.use("/:roomID", confirmUserInRoom);
-router.use("/:roomID/markdown", filesRouter);
+router.use("/:roomID/files", filesRouter);
 
 export default router;


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
Client API wrappers for file related endpoints.

## Description
Added client APIs for all endpoints defined in the server (create, enumerate, get, update, and delete). Needed for client-server interaction.

## Changelog
Added client/src/api/files.ts, modified client/src/api/index.ts

## Footer
Reference number: #45 
Closes: #45 
