### PR TITLE
ignore @tiptap/pm in dll

### DIFF
--- a/client/.erb/configs/webpack.config.renderer.dev.dll.ts
+++ b/client/.erb/configs/webpack.config.renderer.dev.dll.ts
@@ -31,7 +31,7 @@ const configuration: webpack.Configuration = {
   module: require('./webpack.config.renderer.dev').default.module,
 
   entry: {
-    renderer: Object.keys(dependencies || {}),
+    renderer: Object.keys(dependencies || {}).filter((dep) => !(dep === '@tiptap/pm')),
   },
 
   output: {


### PR DESCRIPTION
## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
Ignored @tiptap/pm in dll script when installing dependencies.

## Description
This module caused the dll build to fail, even though the submodule was not problematic. Ignoring it suppresses the error message.

## Changelog
client/.erb

## Footer
Reference number: #120 
Closes: #120 
