### PR TITLE
rate limiter for authMiddleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "express-ws": "^5.0.2",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7,6 +7,13 @@ import roomsRouter from "./rooms.routes";
 
 import { authMiddleware } from "../middleware/setup"
 import { ErrorCatcher } from "../middleware/errorCatcher";
+import rateLimit from "express-rate-limit";
+
+// rate limit to 1000 rq per 15min
+const limiter = rateLimit({
+    windowMs: 15*60*1000,
+    max: 1000
+}); 
 
 const router = Router();
 
@@ -14,6 +21,7 @@ router.use("/", miscRouter);
 router.use("/user", userRouter);
 
 router.use(ErrorCatcher(authMiddleware));
+router.use(limiter, authMiddleware);
 
 router.use("/admin", adminRouter);
 router.use("/rooms", roomsRouter);

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -4,12 +4,20 @@ import * as controller from "../controllers/user.controller";
 import { authMiddleware } from "../middleware/setup"
 import { ErrorCatcher } from "../middleware/errorCatcher";
 
+import rateLimit from "express-rate-limit";
+
+// rate limit to 1000 rq per 15min
+const limiter = rateLimit({
+    windowMs: 15*60*1000,
+    max: 1000
+}); 
 
 const router = Router();
 
 router.post("/authenticate", ErrorCatcher(controller.authenticate));
 
 router.use(ErrorCatcher(authMiddleware));
+router.use(limiter, authMiddleware);
 
 router.get("/", ErrorCatcher(controller.getUserDetails));
 router.get("/all", ErrorCatcher(controller.getAllUsers));


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update

## Abstract
rate limit all authed endpoints

## Description
prevent attacks on endpoints which are critical to system running by limiting to 1000 per 15min

## Changelog
What parts of the repo where changed

## Footer
Reference number: which issue or project does this relate to
Closes: which issue or project does this finish
